### PR TITLE
Fix SPI DMA

### DIFF
--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -518,7 +518,7 @@ macro_rules! impl_write {
 
             fn rx_address_count(&self) -> (u32, u32) {
                 (
-                    &self.device.sspdr() as *const _ as u32,
+                    self.device.sspdr() as *const _ as u32,
                     u32::MAX,
                 )
             }
@@ -541,7 +541,7 @@ macro_rules! impl_write {
 
             fn tx_address_count(&mut self) -> (u32, u32) {
                 (
-                    &self.device.sspdr() as *const _ as u32,
+                    self.device.sspdr() as *const _ as u32,
                     u32::MAX,
                 )
             }


### PR DESCRIPTION
This fixes the on-target tests.
But we still have to check that we don't have the same issue in other places, where it's not covered by the tests.

The bug is dangerous as there is no warning if we cast `&&SSPDR` instead of `&SSPDR` to `*const _`, but of course the resulting address will be nonsense.  This can happen wherever we take the address of some register.